### PR TITLE
Add prop types to ludole application

### DIFF
--- a/src/components/Game/Game.jsx
+++ b/src/components/Game/Game.jsx
@@ -5,6 +5,7 @@ import GameStatus from "../GameStatus/GameStatus";
 import Guesses from "../Guesses/Guesses";
 import ImageBlur from "../ImageBlur/ImageBlur";
 import "./Game.css";
+import PropTypes from "prop-types"
 
 export default function Game({ games, totalGuesses = 8 }) {
   const [guessCount, setGuessCount] = useState(0);
@@ -69,3 +70,22 @@ export default function Game({ games, totalGuesses = 8 }) {
     </main>
   );
 }
+
+const gamesPropTypes = PropTypes.arrayOf(
+  PropTypes.shape({
+    id: PropTypes.number.isRequired,
+    title: PropTypes.string.isRequired,
+    imagesrc: PropTypes.string.isRequired,
+    year: PropTypes.number.isRequired,
+    genre: PropTypes.arrayOf(PropTypes.string).isRequired,
+    themes: PropTypes.arrayOf(PropTypes.string).isRequired,
+    console: PropTypes.arrayOf(PropTypes.string).isRequired,
+    developer: PropTypes.arrayOf(PropTypes.string).isRequired,
+    publisher: PropTypes.arrayOf(PropTypes.string).isRequired,
+  })
+);
+
+Game.propTypes = {
+  games: gamesPropTypes.isRequired,
+  totalGuesses: PropTypes.number,
+};

--- a/src/components/GameStatus/GameStatus.jsx
+++ b/src/components/GameStatus/GameStatus.jsx
@@ -1,5 +1,6 @@
 //basing props coming in off:
 // ex: 3, 9, true
+import PropTypes from "prop-types"
 
 import "./GameStatus.css";
 
@@ -14,4 +15,10 @@ export default function GameStatus({ numGuesses, totalGuesses, hasWon }) {
     }
   };
   return <div className="game-status">{getDisplay()}</div>;
+}
+
+GameStatus.propTypes = {
+  numGuesses: PropTypes.number.isRequired,
+  totalGuesses: PropTypes.number.isRequired,
+  hasWon: PropTypes.bool.isRequired
 }

--- a/src/components/Guesses/Guesses.jsx
+++ b/src/components/Guesses/Guesses.jsx
@@ -1,4 +1,5 @@
 import "./Guesses.css";
+import PropTypes from "prop-types";
 
 //basing this off data from guessArray coming in to be ['guess string', '25' - 25 being the percentage correct] - Hopefully that works
 
@@ -35,3 +36,13 @@ export default function Guesses({ totalGuesses = 8, guessArray = [] }) {
 
   return <div className="guess-container">{boxElements}</div>;
 }
+
+Guesses.propTypes = {
+  totalGuesses: PropTypes.number,
+  guessArray: PropTypes.arrayOf(
+    PropTypes.oneOfType([
+      PropTypes.string, // assuming guess string
+      PropTypes.oneOfType([PropTypes.string, PropTypes.number]), // assuming percentage string or number
+    ])
+  ),
+};

--- a/src/components/ImageBlur/ImageBlur.jsx
+++ b/src/components/ImageBlur/ImageBlur.jsx
@@ -1,4 +1,5 @@
 import "./ImageBlur.css";
+import PropTypes from "prop-types";
 
 export default function ImageBlur({
   src,
@@ -16,5 +17,13 @@ export default function ImageBlur({
     </div>
   );
 }
+
+ImageBlur.propTypes = {
+  src: PropTypes.string.isRequired,
+  blur: PropTypes.number,
+  width: PropTypes.string,
+  height: PropTypes.string,
+  alt: PropTypes.string.isRequired,
+};
 
 //https://www.kalmbachfeeds.com/cdn/shop/articles/two-white-ducks-in-grass.jpg?v=1706873608 sample image to plug into src if you would like to see it working,


### PR DESCRIPTION
# Description

Prop type checking was added to the app to ensure the correct data types are being passed in. 

## Context

Prior to the PR Game, GameStatus, Guesses, and ImageBlur components did not have a way to make sure the data being passed in as props was the correct type of data. This could have led to unforeseen bugs and errors. Our motivation behind adding prop types was to handle any of those unforeseen issues before they have a chance to affect our UI/UX. Dependencies for prop types were already installed prior to this PR.  

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tests were done locally by interacting with the app and viewing the console to ensure no errors are present in the prop type checking. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
