### PR TITLE
bug fix to resolve prop types error

### DIFF
--- a/src/components/Guesses/Guesses.jsx
+++ b/src/components/Guesses/Guesses.jsx
@@ -38,11 +38,13 @@ export default function Guesses({ totalGuesses = 8, guessArray = [] }) {
 }
 
 Guesses.propTypes = {
-  totalGuesses: PropTypes.number,
+  totalGuesses: PropTypes.number.isRequired,
   guessArray: PropTypes.arrayOf(
-    PropTypes.oneOfType([
-      PropTypes.string, // assuming guess string
-      PropTypes.oneOfType([PropTypes.string, PropTypes.number]), // assuming percentage string or number
-    ])
-  ),
+    PropTypes.arrayOf(
+      PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.number
+      ])
+    )
+  ).isRequired,
 };


### PR DESCRIPTION
# Description

Bug fix in Guesses component. Prop types for the incoming guesses array was failing

## Context

Previously the prop type was expecting an incoming array of nested arrays, and each of those nested arrays to have a string and another array. This was faulty, as the incoming prop is only sending an array of nested arrays that only contain a string and a number. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This has been tested locally by entering any number of guesses from 1 to 8 and ensuring no errors in the console. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
