### PR TITLE
fix: Will assign default point of one to guesses that make it past va…

### DIFF
--- a/src/javascript/guess.js
+++ b/src/javascript/guess.js
@@ -8,7 +8,7 @@ export function compareGuesses(guess, answer) {
 
   // we test for 7 categories and 7 * 14 = 98 which is the closest to 100
   const MAX_POINTS = 14;
-  let points = 0;
+  let points = 1;
 
   const calculateSimilarity = (comparisonArray, targetArray) => {
     return (


### PR DESCRIPTION
…lidation.

# Description

This will fix the bug depicted in #20 

## Context

This fix works by making the initial value of points 1 instead of 0 since invalid guesses will already return a value of 0, this prevents guesses that make it past that check of being assigned 0 points.

Fixes #20 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was tested manually in the same context the bug was noticed in screenshot below:
<img width="822" alt="Screenshot 2024-05-26 at 12 48 32 PM" src="https://github.com/KojinKuro/ludole/assets/155918416/a6a063c1-209a-4bc1-8cee-a336167923e0">

When we have the ability to do so this can be verified in a larger set of cases, my only concern is that perhaps with my fix a guess that is incorrect could somehow receive a 100 if it is very close. Thought this at least does not happen in the only current case I'd imagine it happening:

<img width="818" alt="Screenshot 2024-05-26 at 1 00 46 PM" src="https://github.com/KojinKuro/ludole/assets/155918416/95644692-062c-4e3a-bd98-ed713d2512ca">


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
