### PR TITLE
Allow manual setting of answer

### DIFF
--- a/cypress/e2e/routing.cy.js
+++ b/cypress/e2e/routing.cy.js
@@ -1,51 +1,40 @@
-
-describe('basic function check', () => {
-  it('is server running? are tests working?', () => {
-    cy.visit('http://127.0.0.1:5173/')
+describe("basic function check", () => {
+  it("is server running? are tests working?", () => {
+    cy.visit("http://127.0.0.1:5173/");
   });
 });
 
-describe('Direct Url Navigation.', () => {
-  it('As a user, the default path should land me on the homepage game.', () => {
-    cy.visit('http://127.0.0.1:5173/')
-    .get('.guess-container > :nth-child(1)');
+describe("Direct Url Navigation.", () => {
+  it("As a user, the default path should land me on the homepage game.", () => {
+    cy.visit("http://127.0.0.1:5173/").get(".guess-container > :nth-child(1)");
   });
-  it('If I go to the path /about I should be taken to a page describing the game and its developers.',()=>{
-    cy.visit('http://127.0.0.1:5173/about')
-    .get('h1')
-    .contains('About');
+  it("If I go to the path /about I should be taken to a page describing the game and its developers.", () => {
+    cy.visit("http://127.0.0.1:5173/about").get("h1").contains("About");
   });
-  it('If I go to the path /howto, I should be taken to a page describing how to play.',()=>{
-    cy.visit('http://127.0.0.1:5173/howto')
-    .get('h1')
-    .contains('How to');
+  it("If I go to the path /howto, I should be taken to a page describing how to play.", () => {
+    cy.visit("http://127.0.0.1:5173/howto").get("h1").contains("How to");
   });
-  it('If I go to a made up path, it should take me to the landing page',()=>{
-    cy.visit('http://127.0.0.1:5173/abofdsffut')
-    .get('.guess-container > :nth-child(1)');
+  it("If I go to a made up path, it should take me to the landing page", () => {
+    cy.visit("http://127.0.0.1:5173/abofdsffut").get(
+      ".guess-container > :nth-child(1)"
+    );
   });
 });
 
-describe('Click Navigation.', () => {
-  beforeEach(()=>{
-    cy.visit('http://127.0.0.1:5173/')
+describe("Click Navigation.", () => {
+  beforeEach(() => {
+    cy.visit("http://127.0.0.1:5173/");
   });
-  it('As a user, if I click the i icon I should be taken to the about page.', () => {
-    cy.get('[href="/about"] > box-icon')
-    .click()
-    .get('h1')
-    .contains('About');
+  it("As a user, if I click the i icon I should be taken to the about page.", () => {
+    cy.get('[href="/about"] > box-icon').click().get("h1").contains("About");
   });
-  it('As a user, if I click the question-mark I will be taken to the how to play page.',()=>{
-    cy.get('[href="/howto"] > box-icon')
-    .click()
-    .get('h1')
-    .contains('How to');
+  it("As a user, if I click the question-mark I will be taken to the how to play page.", () => {
+    cy.get('[href="/howto"] > box-icon').click().get("h1").contains("How to");
   });
-  it('As a user, if I click the Ludole logo I should be taken back to the home page.',()=>{
-    cy.visit('http://127.0.0.1:5173/howto')
-    .get('[href="/"] > box-icon')
-    .click()
-    .get('.guess-container > :nth-child(1)');
+  it("As a user, if I click the Ludole logo I should be taken back to the home page.", () => {
+    cy.visit("http://127.0.0.1:5173/howto")
+      .get('[href="/"] > box-icon')
+      .click()
+      .get(".guess-container > :nth-child(1)");
   });
 });

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -1,39 +1,33 @@
-
-describe('basic function check', () => {
-  it('is server running? are tests working?', () => {
-    cy.visit('http://127.0.0.1:5173/')
-  })
-})
-
-describe('Landing page game.', () => {
-  beforeEach(()=>{
-    cy.visit('http://127.0.0.1:5173/')
-  });
-  it('As a user if I make a guess that is not currently in the possible titles, my guess will not be processed.', () => {
-    cy.get('input')
-    .type('hello')
-    .get('button')
-    .click()
-    cy.get('.guess-container > :nth-child(1)')
-    .invoke('attr','class')
-    .should('contain', 'grey');
-  });
-  it('As a user once I make an acceptable guess this should be reflected on the page.', ()=>{
-    cy.get('input')
-    .type("The Elder Scrolls V: Skyrim")
-    .get('button')
-    .click()
-    .get('h2')
-    .should('contain', '1/8')
-  });
-  it('If I have not made a guess, the image should be fully blurred',()=>{
-    cy.get('img')
-    .invoke('attr','style')
-    .should('contain', '50px')
+describe("basic function check", () => {
+  it("is server running? are tests working?", () => {
+    cy.visit("http://127.0.0.1:5173/");
   });
 });
 
-/**
+describe("Landing page game.", () => {
+  beforeEach(() => {
+    cy.visit("http://127.0.0.1:5173/");
+  });
+  it("As a user if I make a guess that is not currently in the possible titles, my guess will not be processed.", () => {
+    cy.get("input").type("hello").get("button").click();
+    cy.get(".guess-container > :nth-child(1)")
+      .invoke("attr", "class")
+      .should("contain", "grey");
+  });
+  it("As a user once I make an acceptable guess this should be reflected on the page.", () => {
+    cy.get("input")
+      .type("The Elder Scrolls V: Skyrim")
+      .get("button")
+      .click()
+      .get("h2")
+      .should("contain", "1/8");
+  });
+  it("If I have not made a guess, the image should be fully blurred", () => {
+    cy.get("img").invoke("attr", "style").should("contain", "50px");
+  });
+});
+
+/*
 //The below code will be available to implement once we have api calls to intercept, it was tested by editing mock data to only include the first .
 describe('Correct guesses tests',()=>{
   beforeEach(()=>{
@@ -69,3 +63,4 @@ describe('Correct guesses tests',()=>{
   });
 });
 
+*/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,8 +14,6 @@ function App() {
           <h1>LUDOLE</h1>
         </Link>
         <nav>
-          {/* <box-icon color="white" type="solid" name="calendar" />
-          <box-icon color="white" name="bar-chart-alt-2" type="solid" /> */}
           <NavLink to="/about">
             <box-icon color="black" name="info-circle" />
           </NavLink>

--- a/src/components/SearchBar/SearchBar.jsx
+++ b/src/components/SearchBar/SearchBar.jsx
@@ -87,7 +87,7 @@ export default function SearchBar({ games, onSearch = () => {} }) {
           <div className="search-results-container">{searchResultsJSX}</div>
         )}
       </div>
-      {/* <button onClick={() => submitSearch(searchInput)}>Submit</button> */}
+      <button onClick={() => submitSearch(searchInput)}>Submit</button>
     </div>
   );
 }

--- a/src/pages/GamePage.jsx
+++ b/src/pages/GamePage.jsx
@@ -8,13 +8,17 @@ import { findGameObject } from "../javascript/game";
 import { compareGuesses, createGuess } from "../javascript/guess";
 import "./GamePage.css";
 
-export default function GamePage({ games, totalGuesses = 8 }) {
+export default function GamePage({
+  games,
+  totalGuesses = 8,
+  answerIndex = Math.floor(Math.random() * games.length),
+}) {
   const [guessCount, setGuessCount] = useState(0);
   const [guessHistory, setGuessHistory] = useState([]);
 
   const [hasWon, setHasWon] = useState(false);
 
-  const answer = useRef(games[Math.floor(Math.random() * games.length)]);
+  const answer = useRef(games[answerIndex]);
 
   const addGuess = (guess) => {
     setGuessHistory((prevHistory) => [...prevHistory, guess]);
@@ -68,4 +72,5 @@ const gamesPropTypes = PropTypes.arrayOf(
 GamePage.propTypes = {
   games: gamesPropTypes.isRequired,
   totalGuesses: PropTypes.number,
+  answerIndex: PropTypes.number,
 };


### PR DESCRIPTION
# Description

Allow manual setting of a ludole answer.

## Context

- Allow manual setting of the correct answer by adding `answerIndex` as a prop for any `<GamePage />` component. The `answerIndex` will default to being random if none is given (which is how we had it before). `answerIndex` must be from 0 to `games.length`. This allows us to manually set what games we are checking, and what the answer is by passing them in as props.
- Remove old comments for features outside of MVP.
- Added back in search bar button due to Cypress testing expecting it to exist.

Fixes #25 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

This code does not have any Cypress testing done will be done as part of the #27 task. Manual testing was done by changing the `<GamePage />` route in `App.jsx` to have a prop of `answerIndex={someNumber}`. The `answerIndex` will set the answer of the ludole to always be the game at `answerIndex` index position of the `games` array.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
